### PR TITLE
fix: null channel id in .exp command removed

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## September 2022
 | *date*     | *prefix* | *description*                                |
 |------------|----------|----------------------------------------------|
-| 09/17/2022 | fix      | Fix null channel id in .experimental command |
+| 09/16/2022 | fix      | Fix null channel id in .experimental command |
 
 ## August 2022
 | *date*     | *prefix* | *description*                           |

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+## September 2022
+| *date*     | *prefix* | *description*                                |
+|------------|----------|----------------------------------------------|
+| 09/17/2022 | fix      | Fix null channel id in .experimental command |
+
 ## August 2022
 | *date*     | *prefix* | *description*                           |
 |------------|----------|-----------------------------------------|

--- a/src/commands/B78XH/experimental.ts
+++ b/src/commands/B78XH/experimental.ts
@@ -12,7 +12,7 @@ export const experimental: CommandDefinition = {
         const experimentalEmbed = makeEmbed({
             title: 'Heavy Division | Experimental Version',
             description: makeLines([
-                `Check <#${Channels.LINKS}> to see the current uses of the experimental build. **No support will be offered via Discord.** `,
+                `Check <#${Channels.DOWNLOAD_LINKS}> to see the current uses of the experimental build. **No support will be offered via Discord.** `,
                 '',
                 'Please use the appropriate discord thread to discuss any issues: ',
                 '- <#811459130313015328> ',

--- a/src/commands/B78XH/experimental.ts
+++ b/src/commands/B78XH/experimental.ts
@@ -1,7 +1,7 @@
 // based off FlyByWire Simulations Discord Bot - https://github.com/flybywiresim/discord-bot
 
 import { CommandDefinition } from '../../lib/command';
-import { CommandCategory } from '../../constants';
+import { CommandCategory, Channels } from '../../constants';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const experimental: CommandDefinition = {
@@ -12,7 +12,7 @@ export const experimental: CommandDefinition = {
         const experimentalEmbed = makeEmbed({
             title: 'Heavy Division | Experimental Version',
             description: makeLines([
-                'Check <@channelid> to see the current uses of the experimental build. **No support will be offered via Discord.** ',
+                `Check <#${Channels.LINKS}> to see the current uses of the experimental build. **No support will be offered via Discord.** `,
                 '',
                 'Please use the appropriate discord thread to discuss any issues: ',
                 '- <#811459130313015328> ',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,6 @@ export enum Channels {
     USER_LOGS = '964722187581927475',
     SCAM_LOGS = '964722605783400458',
     DOWNLOAD_LINKS = '852748629877850143',
-    LINKS = '852748629877850143',
 }
 
 export const UserLogExclude = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export enum Channels {
     USER_LOGS = '964722187581927475',
     SCAM_LOGS = '964722605783400458',
     DOWNLOAD_LINKS = '852748629877850143',
+    LINKS = '852748629877850143',
 }
 
 export const UserLogExclude = [


### PR DESCRIPTION
<!-- ## Title -->
fix: null channel id in .exp command removed
<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Adds a channel link that was previously missing in the .experimental command

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
![image](https://user-images.githubusercontent.com/52870481/190676710-84731550-048c-4abc-acfb-117c60f638d2.png)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
HowNowBrownCrow#2591
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
