### PR TITLE
fix: sanitize .tod user input

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,8 @@
 | 11/10/2022 | feat     | Connect db and add temporaryCommands                                 |
 | 11/10/2022 | fix      | Fix temporaryCommands support channel logging and error in changelog |
 | 11/26/2022 | feat     | Cycle Warning Command                                                |
+| 11/29/2022 | fix      | Fix top of descent command to sanitize user input                    |
+
 
 ## October 2022
 | *date*     | *prefix* | *description*                         |

--- a/src/commands/utils/tod.ts
+++ b/src/commands/utils/tod.ts
@@ -3,7 +3,7 @@ import { CommandCategory } from '../../constants';
 import { makeEmbed, makeLines } from '../../lib/embed';
 
 export const rot: CommandDefinition = {
-    name: ['ruleofthree', 'rot', 'ro3'],
+    name: ['ruleofthree', 'rot', 'ro3', 'tod'],
     description: 'Roughly calculates TOD using the rule of 3',
     category: CommandCategory.UTILS,
     // eslint-disable-next-line consistent-return
@@ -12,25 +12,29 @@ export const rot: CommandDefinition = {
 
         const altitude = parseInt(text.replace(/[^0-9.]/g, ''), 10);
 
-        const error = 'Please specify a valid altitude or flight level.';
+        const error = 'Please specify a valid altitude (1000-10,000ft) or flight level between FL100 and FL550.';
 
-        const flightLevelError = 'Hint: Try appending \'FL\' to the beginning of values below 1000';
+        const flightLevelError = 'Hint: Try using the \'Flight Level\' convention for values above 10,000ft up to 50,000ft'
+           + 'E.g. 18000ft = FL180 ';
 
         const errorEmbed = makeEmbed({
-            title: 'Error',
+            title: 'Error | Invalid Input',
             description: error,
         });
 
         const flightLevelerrorEmbed = makeEmbed({
-            title: 'Error',
+            title: 'Error | Use Flight Level Format',
             description: flightLevelError,
         });
 
-        if (Number.isNaN(altitude)) {
+        if (Number.isNaN(altitude) || altitude > 10000) {
             return msg.channel.send({ embeds: [errorEmbed] });
-        } if (!msg.content.includes('FL') && altitude <= 1000) {
+        } if (!text.startsWith('FL') && altitude < 1000) {
             return msg.channel.send({ embeds: [flightLevelerrorEmbed] });
-        } if (altitude <= 1000 && text.startsWith('FL')) {
+        }
+        if (text.startsWith('FL') && altitude > 550) {
+            return msg.channel.send({ embeds: [errorEmbed] });
+        } if (text.startsWith('FL') && altitude <= 550) {
             const todFL = Math.floor(altitude * (1 / 3) * (11 / 10));
 
             const todFlightLevelEmbed = makeEmbed({
@@ -43,7 +47,7 @@ export const rot: CommandDefinition = {
                 fields: [
                     {
                         name: 'This is an **approximation** of your TOD',
-                        value: '*Values may not be entirely accurate',
+                        value: '*Values are an estimate, not exact calculation',
                         inline: false,
                     },
                 ],


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Sanitize user input to keep top of descent calculation estimates within a reasonable estimate. Also updates the error embeds to make user errors more clear.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
### Before: 
<img width="618" alt="Screen Shot 2022-11-29 at 4 53 57 PM" src="https://user-images.githubusercontent.com/52870481/204470411-93e58f7e-aef1-48dc-bd96-3a5436316a66.png">

### After 

<img width="656" alt="Screen Shot 2022-11-29 at 4 55 39 PM" src="https://user-images.githubusercontent.com/52870481/204470734-df48e4e1-8dc0-4cdc-9030-5ad195e2eaaa.png">

<img width="737" alt="Screen Shot 2022-11-29 at 4 52 18 PM" src="https://user-images.githubusercontent.com/52870481/204470152-d1fce905-fe43-4c6d-b7b6-4e22db157610.png">

<img width="709" alt="Screen Shot 2022-11-29 at 4 57 26 PM" src="https://user-images.githubusercontent.com/52870481/204471089-0a3e5890-4ecb-4573-8fc7-02e5fa37b607.png">

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
HowNowBrownCrow#2591
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
